### PR TITLE
Metrics from csv + fix

### DIFF
--- a/prescience_client/bean/evaluation_result.py
+++ b/prescience_client/bean/evaluation_result.py
@@ -209,18 +209,21 @@ class EvaluationResult(TablePrintable, DictPrintable):
     def train(self,
               model_id: str,
               compute_shap_summary: bool = False,
-              chain_metric_task: bool = True
+              chain_metric_task: bool = True,
+              dataset_id: str = None
               ):
         """
         Launch a train task from the current evaluation result for creating a model
         :param model_id: The id that we want for the model
         :param compute_shap_summary: should chain the train task with a compute shap summary task ? (default: false)
         :param chain_metric_task: should chain the train task with a metric task ? (default: true)
+        :param dataset_id: dataset to use for the train (default: None, dataset parent of the evaluation)
         :return: The Train Task object
         """
         return self.prescience.train(
             evaluation_uuid=self.uuid(),
             model_id=model_id,
             compute_shap_summary=compute_shap_summary,
-            chain_metric_task=chain_metric_task
+            chain_metric_task=chain_metric_task,
+            dataset_id=dataset_id
         )

--- a/prescience_client/bean/model_metric.py
+++ b/prescience_client/bean/model_metric.py
@@ -44,10 +44,10 @@ class ModelMetric(TablePrintable, DictPrintable):
         return self.json_dict.get('scores')
 
     def get_roc(self):
-        self.get_scores().get(str(ScoringMetric.ROC_AUC)).get('value')
+        return self.get_scores().get(str(ScoringMetric.ROC_AUC)).get('value')
 
     def get_log_loss(self):
-        self.get_scores().get(str(ScoringMetric.LOG_LOSS)).get('value')
+        return self.get_scores().get(str(ScoringMetric.LOG_LOSS)).get('value')
 
     def get_accuracy(self):
-        self.get_scores().get(str(ScoringMetric.ACCURACY)).get('value')
+        return self.get_scores().get(str(ScoringMetric.ACCURACY)).get('value')

--- a/prescience_client/bean/serving/serving_payload.py
+++ b/prescience_client/bean/serving/serving_payload.py
@@ -70,6 +70,8 @@ class ServingPayload(object):
         self.prescience = prescience
         self.model_evaluator = model_evaluator
 
+        self.input_names = None
+
     def get_payload(self) -> dict:
         """
         Access the request payload dictionary
@@ -137,7 +139,7 @@ class ServingPayload(object):
         Access the result probabilities if any
         :return: the result probabilities if any, an empty dictionary otherwise
         """
-        return {k: v for k, v in  self.get_result_dict().items() if k.startswith('probability')}
+        return {k: v for k, v in self.get_result_dict().items() if k.startswith('probability')}
 
     def get_flow_type(self):
         """
@@ -236,3 +238,10 @@ class ServingPayload(object):
             return self.show_arguments()
         else:
             return self.show_result()
+
+    def get_input_names(self):
+        if self.input_names is not None:
+            return self.input_names
+        else:
+            self.input_names = [payload_input.get_name() for payload_input in self.current_inputs_evaluators()]
+            return self.input_names

--- a/prescience_client/client/prescience_client.py
+++ b/prescience_client/client/prescience_client.py
@@ -291,7 +291,8 @@ class PrescienceClient(object):
               evaluation_uuid: str,
               model_id: str,
               compute_shap_summary: bool = False,
-              chain_metric_task: bool = True
+              chain_metric_task: bool = True,
+              dataset_id: str = None
               ) -> 'TrainTask':
         """
         Launch a train task from an evaluation result for creating a model
@@ -299,13 +300,15 @@ class PrescienceClient(object):
         :param model_id: The id that we want for the model
         :param compute_shap_summary: should chain the train task with a compute shap summary task ? (default: false)
         :param chain_metric_task: should chain the train task with a metric task ? (default: true)
+        :param dataset_id: dataset to use for the train (default: None, dataset parent of the evaluation)
         :return: The Train Task object
         """
         query_parameters = {
             'model_id': model_id,
             'evaluation_uuid': evaluation_uuid,
             'enable_shap_summary': compute_shap_summary,
-            'chain_metric_task': chain_metric_task
+            'chain_metric_task': chain_metric_task,
+            'dataset_id': dataset_id
         }
         _, result, _ = self.__post(path=f'/ml/train', query_parameters=query_parameters)
         from prescience_client.bean.task import TaskFactory
@@ -560,6 +563,23 @@ class PrescienceClient(object):
         from prescience_client.bean.model_metric import ModelMetric
         return ModelMetric(json=metric, prescience=self)
 
+    def model_metric_from_csv(self,
+                      model_id: str,
+                      filepath: str
+                      ) -> 'Task':
+        """
+        Upload a local input file on prescience and launch a Parse Task on it for creating a source.
+        :param model_id: The id of the model to evaluate
+        :param filepath: The path of the local input file
+        :return: The model metric object
+        """
+        _, metric, _ = self.__post(
+            path=f'/metrics/{model_id}/transform-model',
+            filepath=filepath,
+            call_type=PrescienceWebService.SERVING)
+        from prescience_client.bean.model_metric import ModelMetric
+        return ModelMetric(json=metric, prescience=self)
+
     def model_test_evaluation(self, model_id: str) -> 'TestEvaluations':
         """
         Get the test evaluation of a wanted model
@@ -704,7 +724,8 @@ class PrescienceClient(object):
                data=None,
                multipart: list = None,
                query_parameters: dict = None,
-               call_type: PrescienceWebService = PrescienceWebService.API):
+               call_type: PrescienceWebService = PrescienceWebService.API,
+               filepath: str = None):
         """
         Generic HTTP POST call
         :param path: the http path to call
@@ -712,12 +733,16 @@ class PrescienceClient(object):
         :param multipart: The list of multipart part to send. None of any
         :param query_parameters: The dict of query parameters, None if any
         :param call_type: The prescience web service called
+        :param filepath: path ot data file
         :return: The tuple3 : (http response code, response content, cookie token)
         """
 
-        content_type = 'application/json'
-        if multipart is not None:
-            content_type = 'multipart/form-data'
+        if filepath is not None:
+            content_type = 'application/octet-stream'
+        else:
+            content_type = 'application/json'
+            if multipart is not None:
+                content_type = 'multipart/form-data'
         return self.call(
             method='POST',
             path=path,
@@ -725,7 +750,8 @@ class PrescienceClient(object):
             multipart=multipart,
             content_type=content_type,
             query_parameters=query_parameters,
-            call_type=call_type
+            call_type=call_type,
+            filepath=filepath
         )
 
     def __delete(self, path: str):
@@ -763,7 +789,8 @@ class PrescienceClient(object):
             multipart: list = None,
             content_type: str = 'application/json',
             call_type: PrescienceWebService = PrescienceWebService.API,
-            accept: str = 'application/json'
+            accept: str = 'application/json',
+            filepath: str = None
     ):
         """
         Generic HTTP call wrapper for pyCurl
@@ -817,6 +844,13 @@ class PrescienceClient(object):
         if self.config().is_verbose_activated():
             curl.setopt(pycurl.VERBOSE, 1)
 
+        file = None
+        if filepath is not None:
+            file = open(filepath, 'rb')
+            curl.setopt(pycurl.POST, 1)
+            curl.setopt(pycurl.POSTFIELDSIZE, os.stat(filepath).st_size)
+            curl.setopt(pycurl.READDATA, file)
+
         if data is not None:
             curl.setopt(pycurl.POSTFIELDS, json.dumps(data))
 
@@ -842,6 +876,9 @@ class PrescienceClient(object):
         except pycurl.error as error:
             prescience_error = PyCurlExceptionFactory.construct(error)
             self.config().handle_exception(prescience_error)
+        finally:
+            if file is not None:
+                file.close()
 
         status_code = curl.getinfo(pycurl.RESPONSE_CODE)
         response_content = buffer.getvalue()

--- a/prescience_client/commands/start_command.py
+++ b/prescience_client/commands/start_command.py
@@ -528,8 +528,8 @@ class StartAutoML(Command):
 
     def init_from_subparser(self, subparsers, selector):
         super().init_from_subparser(subparsers, selector)
-        self.cmd_parser.add_argument('source-id', type=str, help='The source from which you want to start a AutoML task')
-        self.cmd_parser.add_argument('scoring-metric', type=ScoringMetric, choices=list(ScoringMetric),
+        self.cmd_parser.add_argument('source-id', nargs="?", type=str, help='The source from which you want to start a AutoML task')
+        self.cmd_parser.add_argument('scoring-metric', nargs="?", type=ScoringMetric, choices=list(ScoringMetric),
                                      help=f'The scoring metric to optimize on. If unset it will trigger the interactive mode.')
 
         self.cmd_parser.add_argument('--dataset-id', type=str, help='Name you want for the created dataset')


### PR DESCRIPTION
Add possibility to compute metrics from a csv file
`prescience.model_metric_from_csv(model_id, filepath)`.

New helper method in payload `get_input_names`, returns a string list of input names.

Fix on `ModelMetric`, missing return statements for `get_accuracy`, `get_log_loss` and `get_roc`